### PR TITLE
Use custom class loader to load annotations from pool

### DIFF
--- a/javassist-plugin/build.gradle
+++ b/javassist-plugin/build.gradle
@@ -13,7 +13,7 @@ apply from: rootProject.file('gradle/plugin.gradle')
 apply plugin: 'jacoco'
 apply plugin: 'com.github.kt3k.coveralls'
 
-version = '0.4.0'
+version = '0.4.1'
 
 dependencies {
   compile 'org.javassist:javassist:3.18.2-GA'

--- a/javassist-plugin/src/main/java/com/darylteo/gradle/javassist/tasks/TransformationAction.java
+++ b/javassist-plugin/src/main/java/com/darylteo/gradle/javassist/tasks/TransformationAction.java
@@ -2,6 +2,7 @@ package com.darylteo.gradle.javassist.tasks;
 
 import javassist.ClassPool;
 import javassist.CtClass;
+import javassist.Loader;
 import javassist.NotFoundException;
 import javassist.build.IClassTransformer;
 import org.gradle.api.GradleException;
@@ -58,7 +59,7 @@ class TransformationAction {
   }
 
   private ClassPool createPool() throws NotFoundException {
-    final ClassPool pool = new ClassPool(true);
+    final ClassPool pool = new AnnotationLoadingClassPool();
 
     // set up the classpath for the classpool
     if (classpath != null) {
@@ -106,4 +107,19 @@ class TransformationAction {
 
     return clazz;
   }
+
+    /**
+     * This class loader will load annotations encountered in loaded classes
+     * using the pool itself.
+     * @see <a href="https://github.com/jboss-javassist/javassist/pull/18">Javassist issue 18</a>
+     */
+    private static class AnnotationLoadingClassPool extends ClassPool {
+        public AnnotationLoadingClassPool() {
+            super(true);
+        }
+
+        @Override public ClassLoader getClassLoader() {
+            return new Loader(this);
+        }
+    }
 }


### PR DESCRIPTION
This small change enables to load annotation properly when loading a class that contains an annotation. 

https://github.com/jboss-javassist/javassist/pull/18

It will definitely make it much simpler to use the plugin in android as every derived plugin will be able to load annotations from the dependencies of the project where the plugin is applied. Without this change, annotations would have had to be loaded both in the project itself (to compile) and added  to the buildScript scope (to be known by the plugin).

@darylteo , do you think you could release version 0.4.1 soon ? (I increased version number in the PR already)
