### PR TITLE
Preloading project classes before processing.

### DIFF
--- a/javassist-plugin/src/main/java/com/darylteo/gradle/javassist/tasks/TransformationAction.java
+++ b/javassist-plugin/src/main/java/com/darylteo/gradle/javassist/tasks/TransformationAction.java
@@ -21,6 +21,7 @@ class TransformationAction {
   private IClassTransformer transformation;
 
   private List<File> sources = new LinkedList<File>();
+  private List<CtClass> loadedClasses = new LinkedList<>();
   private Collection<File> classpath = new LinkedList<File>();
 
   public TransformationAction(File destinationDir, Collection<File> sources, Collection<File> classpath, IClassTransformer transformation) {
@@ -50,7 +51,7 @@ class TransformationAction {
     try {
       final ClassPool pool = createPool();
 
-      this.process(pool, this.sources);
+      this.process(pool, this.loadedClasses);
     } catch (Exception e) {
       throw new GradleException("Could not execute transformation", e);
     }
@@ -58,7 +59,7 @@ class TransformationAction {
     return true;
   }
 
-  private ClassPool createPool() throws NotFoundException {
+  private ClassPool createPool() throws NotFoundException, IOException {
     final ClassPool pool = new AnnotationLoadingClassPool();
 
     // set up the classpath for the classpool
@@ -70,27 +71,25 @@ class TransformationAction {
 
     // add the files to process
     for (File f : this.sources) {
-      pool.appendClassPath(f.toString());
+      if (!f.isDirectory()) {
+        loadedClasses.add(loadClassFile(pool, f));
+      }
     }
     return pool;
   }
 
-  public void process(ClassPool pool, Collection<File> files) {
-    for (File file : files) {
-      processFile(pool, file);
+  public void process(ClassPool pool, Collection<CtClass> classes) {
+    for (CtClass clazz : classes) {
+      processClass(pool, clazz);
     }
   }
 
-  public void processFile(ClassPool pool, File file) {
+  public void processClass(ClassPool pool, CtClass clazz) {
     try {
-      if (!file.isDirectory()) {
-        CtClass clazz = loadClassFile(pool, file);
-
-        if (transformation.shouldTransform(clazz)) {
-          clazz.defrost();
-          transformation.applyTransformations(clazz);
-          clazz.writeFile(this.destinationDir.toString());
-        }
+      if (transformation.shouldTransform(clazz)) {
+        clazz.defrost();
+        transformation.applyTransformations(clazz);
+        clazz.writeFile(this.destinationDir.toString());
       }
     } catch (Exception e) {
       throw new GradleException("An error occurred while trying to process class file ", e);


### PR DESCRIPTION
Classes were loaded into ClassPool as they were processed. This is not usable when you want to weave bytecode that depends on more than one class.

Now it loads all project classes into ClassPool before processing begins.
